### PR TITLE
fix: support re-editing when text is empty, see #269

### DIFF
--- a/src/generator/Pornhub.vue
+++ b/src/generator/Pornhub.vue
@@ -98,6 +98,8 @@
             prefixText
             }}
           </span>
+          <!-- HACK: meaningless text: ".", just to split input area, see: #269 -->
+          <span style="font-size: 0;">.</span>
           <span
             class="postfix"
             :style="{ color: suffixColor, 'background-color': postfixBgColor }"


### PR DESCRIPTION
It seems that when two input boxes are too close to each other, it is not possible to edit the latter one. So invisible text is used to separate them, and tested that it works.